### PR TITLE
Let caller define data response object

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -39,11 +39,11 @@ export interface ThwackOptions {
   responseType?: ResponseType;
 }
 
-export interface ThwackResponse {
+export interface ThwackResponse<T = any> {
   status: number;
   statusText: string;
   headers: KeyValue;
-  data: any;
+  data: T;
   response: Response;
   options: ThwackOptions;
 }


### PR DESCRIPTION
This PR, if merged, will let the caller define the data response object by passing in a generic type. In the event no generic is passed, we default to `any`

Refs: #6 