### PR TITLE
update abort docs with node example

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,7 +422,7 @@ thwack(url, { signal }).then(handleResponse).catch(handleError);
 controller.abort();
 ```
 
-In node, you can use something like the [abort-controller](https://www.npmjs.com/package/abort-controller) package:
+In NodeJS, you can use something like [abort-controller](https://www.npmjs.com/package/abort-controller).
 
 ```js
 import thwack from 'thwack';

--- a/README.md
+++ b/README.md
@@ -409,7 +409,7 @@ How to
 
 Use an `AbortController` to cancel requests by passing its `signal` in the `thwack` options. 
 
-In the browser, you can use the built in [AbortController](https://developer.mozilla.org/en-US/docs/Web/API/AbortController):
+In the browser, you can use the built-in [AbortController](https://developer.mozilla.org/en-US/docs/Web/API/AbortController).
 
 ```js
 import thwack from 'thwack';

--- a/README.md
+++ b/README.md
@@ -407,9 +407,27 @@ How to
 
 ### Cancelling a request
 
-Use an `AbortController` to cancel requests by passing its `signal` in the `thwack` options:
+Use an `AbortController` to cancel requests by passing its `signal` in the `thwack` options. 
+
+In the browser, you can use the built in [AbortController](https://developer.mozilla.org/en-US/docs/Web/API/AbortController):
 
 ```js
+import thwack from 'thwack';
+
+const controller = new AbortController();
+const { signal } = controller;
+
+thwack(url, { signal }).then(handleResponse).catch(handleError);
+
+controller.abort();
+```
+
+In node, you can use something like the [abort-controller](https://www.npmjs.com/package/abort-controller) package:
+
+```js
+import thwack from 'thwack';
+import AbortController from "abort-controller"
+
 const controller = new AbortController();
 const { signal } = controller;
 


### PR DESCRIPTION
This PR adds an example of how to use `AbortController` in node.  I suggested the `abort-controller` package since it's what `node-fetch` [suggests](https://github.com/node-fetch/node-fetch#request-cancellation-with-abortsignal)