### PR TITLE
Fix lowercase HTTP methods

### DIFF
--- a/__test_utils__/thwackBase.js
+++ b/__test_utils__/thwackBase.js
@@ -113,7 +113,7 @@ const run = async () => {
         expect.objectContaining({
           headers: { 'content-type': 'application/json', ...defaultHeaders },
           body: JSON.stringify(fooBarData),
-          method: 'post',
+          method: 'POST',
         })
       );
     });
@@ -129,7 +129,7 @@ const run = async () => {
         expect.objectContaining({
           headers: { 'content-type': 'text/plain', ...defaultHeaders },
           body: 'this is plain text',
-          method: 'post',
+          method: 'POST',
         })
       );
       await thwack('http://foo.com/', {
@@ -142,7 +142,7 @@ const run = async () => {
         expect.objectContaining({
           headers: { 'content-type': 'application/json', ...defaultHeaders },
           body: JSON.stringify(fooBarData),
-          method: 'post',
+          method: 'POST',
         })
       );
     });
@@ -324,10 +324,10 @@ const run = async () => {
 
     describe('thwack convenience functions', () => {
       // eslint-disable-next-line no-restricted-syntax
-      for (const method of ['post', 'put', 'patch']) {
-        it(`thwack.${method}(name, data, options) defaults to ${method.toUpperCase()} and resolves with a ThwackResponse object`, async () => {
+      for (const method of ['POST', 'PUT', 'PATCH']) {
+        it(`thwack.${method.toLowerCase()}(name, data, options) defaults to ${method} and resolves with a ThwackResponse object`, async () => {
           const fetch = createMockFetch();
-          const data = await thwack[method]('http://foo.com/', 'data', {
+          const data = await thwack[method.toLowerCase()]('http://foo.com/', 'data', {
             fetch,
           });
           expect(fetch).toBeCalledWith(
@@ -346,10 +346,10 @@ const run = async () => {
       }
 
       // eslint-disable-next-line no-restricted-syntax
-      for (const method of ['get', 'delete', 'head']) {
-        it(`thwack.${method}(name, options) defaults to ${method.toUpperCase()} and resolves with a ThwackResponse object`, async () => {
+      for (const method of ['GET', 'DELETE', 'HEAD']) {
+        it(`thwack.${method.toLowerCase()}(name, options) defaults to ${method} and resolves with a ThwackResponse object`, async () => {
           const fetch = createMockFetch();
-          const data = await thwack[method]('http://foo.com/', { fetch });
+          const data = await thwack[method.toLowerCase()]('http://foo.com/', { fetch });
           expect(fetch).toBeCalledWith(
             'http://foo.com/',
             expect.objectContaining({

--- a/src/core/Thwack.js
+++ b/src/core/Thwack.js
@@ -14,13 +14,15 @@ export const createThwack = function (defaults, parent) {
   instance.request = request.bind(instance);
 
   // Create convenience methods on this instance
-  ['get', 'delete', 'head'].forEach((method) => {
-    instance[method] = (url, options) =>
+  ['GET', 'DELETE', 'HEAD'].forEach((method) => {
+    const methodKey = method.toLowerCase();
+    instance[methodKey] = (url, options) =>
       instance.request({ ...options, method, url });
   });
 
-  ['put', 'post', 'patch'].forEach((method) => {
-    instance[method] = (url, data, options) =>
+  ['PUT', 'POST', 'PATCH'].forEach((method) => {
+    const methodKey = method.toLowerCase();
+    instance[methodKey] = (url, data, options) =>
       instance.request({ ...options, method, url, data });
   });
 

--- a/src/core/fetcher.js
+++ b/src/core/fetcher.js
@@ -35,7 +35,7 @@ const fetcher = async function (options) {
 
   const fetchOptions = {
     ...(Object.keys(headers).length !== 0 && { headers }), // add if not empty object
-    ...(!!body && { body, method: 'post' }), // if body not empty add it and default method to POST
+    ...(!!body && { body, method: 'POST' }), // if body not empty add it and default method to POST
     ...rest,
   };
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -25,7 +25,6 @@ export type Method =
   | 'POST'
   | 'put'
   | 'PUT'
-  | 'patch'
   | 'PATCH';
 
 export interface ThwackOptions extends RequestInit {


### PR DESCRIPTION
## This PR
Resolves the issue with the `patch` request being blocked by the CORS policy as described in #31.
The issue originates from the `PATCH` HTTP method being defined in lowercase.

Per [WHATWG fetch spec](https://fetch.spec.whatwg.org/#methods) HTTP methods are case sensitive, so it seems convenient to uppercase all methods as part of the fix.
Besides, the lowercase `patch` value is dropped from the typescript `method` type definition and tests are updated with uppercase methods.